### PR TITLE
Fix Qwen3.5 reasoning routing when thinking is toggled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -352,6 +352,19 @@ COPY fix_qwen3_next_prefix.py /workspace/dgx-vllm-build/fix_qwen3_next_prefix.py
 RUN python3 /workspace/dgx-vllm-build/fix_qwen3_next_prefix.py
 
 # ============================================================================
+# Fix Qwen3.5 reasoning routing when thinking is toggled (MUST be AFTER pip install)
+# ============================================================================
+# Qwen3.5 can reopen thinking at request time via chat_template_kwargs, but
+# older parser logic leaks reasoning text into `content` because generated
+# deltas often start after a prompt-prefilled `<think>` token. Patch the parser
+# so disabled-thinking stays content-only and explicit thinking routes through
+# `reasoning` / `delta.reasoning`.
+# Validated on: Sehyo/Qwen3.5-35B-A3B-NVFP4
+# ============================================================================
+COPY fix_qwen35_reasoning_parser.py /workspace/dgx-vllm-build/fix_qwen35_reasoning_parser.py
+RUN python3 /workspace/dgx-vllm-build/fix_qwen35_reasoning_parser.py
+
+# ============================================================================
 # Fix NVFP4 EMULATION backend dequantization (MUST be AFTER pip install)
 # ============================================================================
 # Two bugs in run_nvfp4_emulations():

--- a/fix_qwen35_reasoning_parser.py
+++ b/fix_qwen35_reasoning_parser.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Fix Qwen3.5 reasoning routing when enable_thinking is toggled.
+
+Validated on:
+  - Sehyo/Qwen3.5-35B-A3B-NVFP4
+
+Problem:
+  - With `--default-chat-template-kwargs {"enable_thinking":false}` plus
+    request-level `chat_template_kwargs={"enable_thinking": true}`, Qwen3.5
+    can reopen thinking, but older vLLM parser logic leaks reasoning text into
+    `content` because the generated stream often starts after a prompt-prefilled
+    `<think>` token.
+
+Fix:
+  - Capture `enable_thinking` from chat template kwargs in the parser.
+  - Route disabled-thinking requests as plain content.
+  - Route explicit-thinking deltas into the reasoning lane even when the start
+    token is already present in the prompt.
+"""
+
+from pathlib import Path
+
+
+path = Path("/app/vllm/vllm/reasoning/qwen3_reasoning_parser.py")
+content = path.read_text()
+
+if "self.thinking_enabled = bool(chat_template_kwargs.get(\"enable_thinking\", True))" in content:
+    print("SKIP: qwen35 reasoning routing fix already present")
+    raise SystemExit(0)
+
+replacement = """# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
+)
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.tokenizers import TokenizerLike
+
+
+class Qwen3ReasoningParser(BaseThinkingReasoningParser):
+    \"""
+    Reasoning parser for the Qwen3 model.
+
+    Qwen3 uses <think>...</think> tokens to denote reasoning text, but when
+    `<think>` is already present in the rendered prompt the generated stream
+    often begins with reasoning text directly. This parser keeps the legacy
+    Qwen3 non-streaming behavior while adding enough state to distinguish:
+    - thinking disabled: return plain content
+    - thinking enabled with prompt-prefilled <think>: treat deltas as reasoning
+      until </think> appears
+    \"""
+
+    @property
+    def start_token(self) -> str:
+        return "<think>"
+
+    @property
+    def end_token(self) -> str:
+        return "</think>"
+
+    def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        chat_template_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+        self.thinking_enabled = bool(chat_template_kwargs.get("enable_thinking", True))
+
+    def extract_reasoning(
+        self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
+    ) -> tuple[str | None, str | None]:
+        \"""
+        Extract reasoning content from the full model output.
+
+        When thinking is disabled, all generated text should remain content.
+        When thinking is enabled but the generation has not yet closed with
+        </think>, treat the whole output as reasoning rather than leaking it
+        into final content.
+        \"""
+        if not self.thinking_enabled:
+            return None, model_output
+
+        if self.end_token not in model_output:
+            return model_output, None
+
+        return super().extract_reasoning(model_output, request)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        \"""
+        Extract reasoning deltas for Qwen3 streaming output.
+
+        Qwen3 may start streaming reasoning text without re-emitting `<think>`
+        because the token already exists in the prompt. In that case, deltas
+        before `</think>` must still be routed to the reasoning lane.
+        \"""
+        if not self.thinking_enabled:
+            return DeltaMessage(content=delta_text) if delta_text else None
+
+        if (
+            self.start_token_id not in previous_token_ids
+            and self.start_token_id not in delta_token_ids
+        ):
+            if self.end_token_id in delta_token_ids:
+                end_index = delta_text.find(self.end_token)
+                reasoning = delta_text[:end_index] if end_index >= 0 else delta_text
+                content = (
+                    delta_text[end_index + len(self.end_token) :]
+                    if end_index >= 0
+                    else None
+                )
+                return DeltaMessage(
+                    reasoning=reasoning or None,
+                    content=content or None,
+                )
+
+            if self.end_token_id in previous_token_ids:
+                return DeltaMessage(content=delta_text) if delta_text else None
+
+            return DeltaMessage(reasoning=delta_text) if delta_text else None
+
+        return super().extract_reasoning_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        )
+"""
+
+path.write_text(replacement)
+print("Applied Qwen3.5 reasoning routing fix")


### PR DESCRIPTION
## Summary

Fix Qwen3.5 reasoning routing when `enable_thinking` is toggled at request time.

This adds a small post-install patch script that updates `qwen3_reasoning_parser.py` so:

- `enable_thinking=false` stays content-only
- `enable_thinking=true` routes reasoning into `message.reasoning` / `delta.reasoning`
- prompt-prefilled `<think>` no longer causes reasoning text to leak into `content`

## Why

On the current Avarok runtime, Qwen3.5 can reopen thinking via request-level
`chat_template_kwargs.enable_thinking=true` once `--generation-config vllm` is
enabled, but reasoning text still leaks into `content` because the generated
stream often starts after a prompt-prefilled `<think>` token.

This patch keeps the fix local to the parser layer and avoids unrelated runtime
or schema changes.

## Validation

Validated locally on GB10 with:

- runtime base: `avarok/dgx-vllm-nvfp4-kernel:v23`
- model: `Sehyo/Qwen3.5-35B-A3B-NVFP4`

Observed behavior after the patch:

- baseline non-thinking request -> `content="OK"`, `reasoning=null`
- `chat_template_kwargs.enable_thinking=false` -> `content="OK"`, `reasoning=null`
- `chat_template_kwargs.enable_thinking=true` -> reasoning routed to `message.reasoning`
- streaming `enable_thinking=true` -> reasoning routed to `delta.reasoning`
- downstream Bifrost/OpenClaw smoke test still returned `OK`

## Scope

This PR intentionally does **not**:

- change OpenAI request schema
- change serving path wiring
- pull in broader upstream vLLM parser/serving changes

It only adds a small Qwen3.5 parser carry patch in the same style as the other
post-install fix scripts already used in this repo.
