### PR TITLE
Add SECURITY.md and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Base image (FROM nvidia/cuda:... in Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions used by .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    # Group all minor/patch actions bumps into one PR; majors stay separate
+    # so they can be reviewed individually (the API can change).
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately to **contact@avarok.net** rather than
+opening a public GitHub issue. A maintainer will follow up to triage and
+coordinate a fix.
+
+If you don't get a response within a few business days, feel free to ping a
+maintainer directly on github (mention is fine, no details in the public
+thread please).
+
+## Supported versions
+
+Only the most recent tagged image is supported for security updates.
+
+| Version    | Supported          |
+|------------|--------------------|
+| latest (`v22`) | :white_check_mark: |
+| < v22      | :x:                |
+
+If you're running an older tag and can't upgrade, mention that in your report
+and we'll do our best to advise on mitigations.
+
+## Scope
+
+In scope:
+
+- The Docker image published as `avarok/vllm-dgx-spark` / `avarok/dgx-vllm-nvfp4-kernel`
+- The build scripts in this repo (Dockerfile, `*.sh`, `fix_*.py`)
+- The custom CUTLASS NVFP4 kernels in `cutlass_nvfp4/` and `sparse_fp4_kernel/`
+
+Out of scope:
+
+- Upstream vLLM, FlashInfer, CUTLASS, or PyTorch issues — please report those
+  to the respective projects. We'll happily forward if you're unsure where it
+  belongs.
+- Issues that require physical access to the host
+
+## Disclosure
+
+We'd appreciate a reasonable embargo window (~90 days) for any kernel-level
+findings — these can take real work to patch without breaking the
+sm_121a path. For pure dependency-bump issues, just open a PR.


### PR DESCRIPTION
Two small hygiene additions, no code changes.

`SECURITY.md` -- gives folks a private channel for vuln reports instead of filing public issues. Pointed at contact@avarok.net since that's the verified org contact on the github org; swap if there's a better mailbox.

`.github/dependabot.yml` -- weekly bumps for the Dockerfile base image (nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04 today) and the github actions used in the workflows. Minor/patch action bumps grouped into one PR per week so the noise stays low. Majors come through individually so the changelog actually gets read.

Pip ecosystem isn't included since python deps are installed inline in the Dockerfile rather than a requirements.txt at the repo root. Happy to add that ecosystem in a follow-up if you'd rather extract a top-level requirements file.

fyi -- I'm a downstream user; pulled v22 onto a GB10 box this week and ran a security retro on the stack. The only runtime-reachable HIGH was CVE-2026-27893 in the pinned vllm dev build, which dependabot would have flagged when vllm 0.18.0 dropped. That's the motivation here -- the config catches the next one of those automatically.

No code touched, no behavior change.
