### PR TITLE
Sign published images with cosign keyless OIDC

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,6 +20,9 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # softprops/action-gh-release needs this on tag pushes
+      id-token: write   # OIDC token for cosign keyless signing
 
     steps:
       - name: Checkout code
@@ -64,6 +67,7 @@ jobs:
             type=raw,value=${{ steps.version.outputs.build_date }},enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -78,7 +82,28 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
 
       - name: Image digest
-        run: echo ${{ steps.meta.outputs.digest }}
+        run: echo "${{ steps.build.outputs.digest }}"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign image with cosign (keyless OIDC)
+        # Signs the manifest digest -- all tags pointing at the same digest
+        # are covered by one signature. Keyless OIDC means no secrets to manage;
+        # the signing cert is bound to the workflow + commit via Fulcio/Rekor.
+        #
+        # Consumers can verify with:
+        #   cosign verify avarok/vllm-dgx-spark:v22 \
+        #     --certificate-identity-regexp "^https://github\.com/Avarok-Cybersecurity/dgx-vllm/" \
+        #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+        run: |
+          cosign sign --yes \
+            "${IMAGE}@${DIGEST}"
+        env:
+          IMAGE: ${{ env.DOCKER_HUB_REPO }}
+          DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Create GitHub Release (on tag)
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Adds sigstore keyless signing to the docker build/push workflow. Each pushed image gets a Rekor-logged signature bound to this repo + the workflow run; no secrets to manage and no private keys to rotate.

Three small changes in the workflow:

1. `permissions: { id-token: write, contents: write }` on the job. id-token is required for the OIDC exchange; contents:write was implicit before but needs to be explicit once any permission is declared (otherwise softprops/action-gh-release breaks on tag pushes).
2. `id: build` on the docker/build-push step so we can reference the real digest. The existing "Image digest" step was reading `steps.meta.outputs.digest`, which doesn't exist on the metadata action -- it just printed an empty line. Now it prints the actual sha. Side benefit of this PR.
3. cosign installer (pinned to v2.4.1) + sign the manifest digest. Signing once covers all tags pointing at that digest (latest, v22, nvfp4, cutlass, the date stamp -- all share one signature).

Consumers can verify:

```
cosign verify avarok/vllm-dgx-spark:v22 \
  --certificate-identity-regexp "^https://github\.com/Avarok-Cybersecurity/dgx-vllm/" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
```

Closes the "no SLSA attestation" gap without forcing key management. Worth mentioning in the README under "How to verify the image" once this lands -- happy to do that as a follow-up PR if you'd like.

Tested locally with `act` -- doesn't fully exercise the OIDC path (act can't issue github tokens) but the YAML parses cleanly and the cosign binary install works on ubuntu-latest. The real test is the first push to main after merge.
